### PR TITLE
Add signals and clean up

### DIFF
--- a/src/ebc_ioctl.rs
+++ b/src/ebc_ioctl.rs
@@ -6,21 +6,21 @@
 typedef int bool;
 
 struct drm_rockchip_ebc_trigger_global_refresh {
-	bool trigger_global_refresh;
+    bool trigger_global_refresh;
 };
 
 #define DRM_IOCTL_ROCKCHIP_EBC_GLOBAL_REFRESH  DRM_IOWR(DRM_COMMAND_BASE + 0x00, struct drm_rockchip_ebc_trigger_global_refresh)
 
 int main()
 {
-	int fd = open("/dev/dri/by-path/platform-fdec0000.ebc-card", DRM_RDWR);
-	if(fd < 0) {
-		return 1;
-	}
-	struct drm_rockchip_ebc_trigger_global_refresh arg;
-	arg.trigger_global_refresh = 1;
-	int ret = ioctl(fd, DRM_IOCTL_ROCKCHIP_EBC_GLOBAL_REFRESH, &arg);
-	return ret;
+    int fd = open("/dev/dri/by-path/platform-fdec0000.ebc-card", DRM_RDWR);
+    if(fd < 0) {
+        return 1;
+    }
+    struct drm_rockchip_ebc_trigger_global_refresh arg;
+    arg.trigger_global_refresh = 1;
+    int ret = ioctl(fd, DRM_IOCTL_ROCKCHIP_EBC_GLOBAL_REFRESH, &arg);
+    return ret;
 }
 
 

--- a/src/ebc_ioctl.rs
+++ b/src/ebc_ioctl.rs
@@ -51,7 +51,6 @@ const DRM_IOCTL_ROCKCHIP_EBC_SET_OFFSCREEN: u64 = 3222299713;
 ioctl_readwrite_bad!(ebc_ioctl_2, DRM_IOCTL_ROCKCHIP_EBC_SET_OFFSCREEN, PayloadEbc2);
 
 pub fn set_offline_screen(new_content: &Vec<u8>) {
-
     println!("Setting offline screen");
     // 1314144
     // let test_content = vec![100u8; 1314144];
@@ -86,7 +85,7 @@ pub fn set_offline_screen(new_content: &Vec<u8>) {
 }
 
 pub fn trigger_global_refresh() {
-    println!("Hello, world!");
+    println!("Triggering global refresh");
     let ebc_device = "/dev/dri/by-path/platform-fdec0000.ebc-card";
     let file = OpenOptions::new()
         .read(true)
@@ -100,7 +99,7 @@ pub fn trigger_global_refresh() {
         let result = ebc_ioctl(file.as_raw_fd(), arg_ptr);
         match result {
             Err(why) => panic!("{:?}", why),
-            Ok(ret) => println!("{}", ret),
+            Ok(_ret) => {},
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,7 +382,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             ("current_mode", ),
             move |_ctx: &mut Context, _dum: &mut EbcObject, ( )| {
                 let ret_value = sys_handler::get_no_off_screen();
-                println!("get_no_off_screen: {}", ret_value);
 
                 Ok((ret_value, ))
             }

--- a/src/sys_handler.rs
+++ b/src/sys_handler.rs
@@ -7,6 +7,7 @@ use std::{
 use std::io::{BufRead, BufReader};
 
 pub fn write_to_file(filename : &str, new_value : &str) {
+    println!("Writing to {filename}: {new_value}");
     let file = OpenOptions::new().write(true)
          .open(filename).expect("Error opening the file");
 
@@ -53,12 +54,12 @@ fn read_ebc_file_bool(parameter: &str) -> bool {
         "0" => false,
         _ => panic!("Unexpected value in sysfs file, expected 'Y' or 'N'"),
     };
-    println!("read_ebc_file_bool({}) {} → {}", parameter, buf.trim(), out);
     return out;
 }
 
 fn write_ebc_file(parameter : &str, new_value : u8) {
     let device = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
+    println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
          .open(device).expect("Error opening the file");
 
@@ -67,6 +68,7 @@ fn write_ebc_file(parameter : &str, new_value : u8) {
 
 fn write_ebc_file_u32(parameter : &str, new_value : u32) {
     let device = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
+    println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
          .open(device).expect("Error opening the file");
 
@@ -76,6 +78,7 @@ fn write_ebc_file_u32(parameter : &str, new_value : u32) {
 pub fn write_ebc_energy_control(new_value : &str) {
     // write: allow only values "on" and "auto"
     let device = format!("/sys/devices/platform/fdec0000.ebc/power/control");
+    println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
          .open(device).expect("Error opening the file");
 

--- a/src/sys_handler.rs
+++ b/src/sys_handler.rs
@@ -38,6 +38,25 @@ fn read_ebc_file(parameter : &str) -> String {
     return buf.trim_end().to_string();
 }
 
+fn read_ebc_file_bool(parameter: &str) -> bool {
+    let parameter_file = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
+    let file = OpenOptions::new().read(true)
+         .open(parameter_file).expect("Error opening the file");
+    let mut reader = BufReader::new(file);
+    let mut buf = String::new();
+    reader.read_line(&mut buf).unwrap();
+
+    let out = match buf.trim() {
+        "Y" => true,
+        "N" => false,
+        "1" => true,
+        "0" => false,
+        _ => panic!("Unexpected value in sysfs file, expected 'Y' or 'N'"),
+    };
+    println!("read_ebc_file_bool({}) {} → {}", parameter, buf.trim(), out);
+    return out;
+}
+
 fn write_ebc_file(parameter : &str, new_value : u8) {
     let device = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
     let file = OpenOptions::new().write(true)
@@ -76,37 +95,20 @@ pub fn read_ebc_energy_control() -> String {
 
 /************************************************************************/
 
-pub fn set_auto_refresh(state: bool) {
-    write_ebc_file("auto_refresh", state as u8);
-    // let ebc_device = "/sys/module/rockchip_ebc/parameters/auto_refresh";
-    // let file = OpenOptions::new().write(true)
-    //      .open(ebc_device).expect("Error opening the file");
-
-    // write!(&file, "{}", state).unwrap();
-}
 
 pub fn get_auto_refresh() -> bool{
-    let ebc_device = "/sys/module/rockchip_ebc/parameters/auto_refresh";
-    let mut file = OpenOptions::new().read(true)
-         .open(ebc_device).expect("Error opening the file");
-
-    let mut state = [0; 1];
-    // let _ = file.by_ref().take(8).read(&mut state);
-    let _ = std::io::Write::by_ref(&mut file).take(8).read(&mut state);
-
-    // state[0] = 0;
-    // let read_result = file.read_exact(&mut state).expect("Reading failed");
-    // // state as bool
-    // true
-    state[0] != 0
+    read_ebc_file_bool("auto_refresh")
+}
+pub fn set_auto_refresh(state: bool) {
+    write_ebc_file("auto_refresh", state as u8);
 }
 
-pub fn get_bw_dither_invert() -> u8{
-    read_ebc_file("bw_dither_invert").parse::<u8>().unwrap()
+pub fn get_bw_dither_invert() -> bool{
+    read_ebc_file_bool("bw_dither_invert")
 }
 
-pub fn set_bw_dither_invert(new_mode: u8){
-    write_ebc_file("bw_dither_invert", new_mode);
+pub fn set_bw_dither_invert(new_mode: bool){
+    write_ebc_file("bw_dither_invert", new_mode as u8);
 }
 
 pub fn get_delay_a() -> u32{
@@ -126,11 +128,7 @@ pub fn set_split_area_limit(new_mode: u32){
 }
 
 pub fn set_default_waveform(waveform: u8) {
-    let ebc_device = "/sys/module/rockchip_ebc/parameters/default_waveform";
-    let file = OpenOptions::new().read(true) .write(true)
-         .open(ebc_device).expect("Error opening the file");
-
-    write!(&file, "{}", waveform).unwrap();
+    write_ebc_file("default_waveform", waveform);
 }
 
 pub fn get_default_waveform() -> u8{
@@ -145,12 +143,12 @@ pub fn set_bw_mode(new_mode: u8){
     write_ebc_file("bw_mode", new_mode);
 }
 
-pub fn get_no_off_screen() -> u8{
-    read_ebc_file("no_off_screen").parse::<u8>().unwrap()
+pub fn get_no_off_screen() -> bool{
+    read_ebc_file_bool("no_off_screen")
 }
 
-pub fn set_no_off_screen(new_mode: u8){
-    write_ebc_file("no_off_screen", new_mode);
+pub fn set_no_off_screen(new_mode: bool){
+    write_ebc_file("no_off_screen", new_mode as u8);
 }
 
 pub fn get_dclk_select() ->u8 {
@@ -165,7 +163,7 @@ pub fn set_dclk_select(new_mode: u8){
 /*
 * [x] auto_refresh
 * [x] bw_dither_invert
-* [ ] bw_mode
+* [x] bw_mode
 * [ ] bw_threshold
 * [x] dclk_select
 * [x] default_waveform

--- a/src/sys_handler.rs
+++ b/src/sys_handler.rs
@@ -9,14 +9,14 @@ use std::io::{BufRead, BufReader};
 pub fn write_to_file(filename : &str, new_value : &str) {
     println!("Writing to {filename}: {new_value}");
     let file = OpenOptions::new().write(true)
-         .open(filename).expect("Error opening the file");
+        .open(filename).expect("Error opening the file");
 
     write!(&file, "{}", new_value).unwrap();
 }
 
 pub fn read_file(filename : &str) -> String {
     let file = OpenOptions::new().read(true)
-         .open(filename).expect("Error opening the file");
+        .open(filename).expect("Error opening the file");
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
     let mut num_bytes = 1;
@@ -31,7 +31,7 @@ pub fn read_file(filename : &str) -> String {
 fn read_ebc_file(parameter : &str) -> String {
     let parameter_file = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
     let file = OpenOptions::new().read(true)
-         .open(parameter_file).expect("Error opening the file");
+        .open(parameter_file).expect("Error opening the file");
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
     let _num_bytes = reader.read_line(&mut buf).unwrap();
@@ -42,7 +42,7 @@ fn read_ebc_file(parameter : &str) -> String {
 fn read_ebc_file_bool(parameter: &str) -> bool {
     let parameter_file = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
     let file = OpenOptions::new().read(true)
-         .open(parameter_file).expect("Error opening the file");
+        .open(parameter_file).expect("Error opening the file");
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
     reader.read_line(&mut buf).unwrap();
@@ -61,7 +61,7 @@ fn write_ebc_file(parameter : &str, new_value : u8) {
     let device = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
     println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
-         .open(device).expect("Error opening the file");
+        .open(device).expect("Error opening the file");
 
     write!(&file, "{}", new_value).unwrap();
 }
@@ -70,7 +70,7 @@ fn write_ebc_file_u32(parameter : &str, new_value : u32) {
     let device = format!("/sys/module/rockchip_ebc/parameters/{parameter}");
     println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
-         .open(device).expect("Error opening the file");
+        .open(device).expect("Error opening the file");
 
     write!(&file, "{}", new_value).unwrap();
 }
@@ -80,7 +80,7 @@ pub fn write_ebc_energy_control(new_value : &str) {
     let device = format!("/sys/devices/platform/fdec0000.ebc/power/control");
     println!("Writing to {device}: {new_value}");
     let file = OpenOptions::new().write(true)
-         .open(device).expect("Error opening the file");
+        .open(device).expect("Error opening the file");
 
     write!(&file, "{}", new_value).unwrap();
 }
@@ -88,7 +88,7 @@ pub fn write_ebc_energy_control(new_value : &str) {
 pub fn read_ebc_energy_control() -> String {
     let parameter_file = format!("/sys/devices/platform/fdec0000.ebc/power/control");
     let file = OpenOptions::new().read(true)
-         .open(parameter_file).expect("Error opening the file");
+        .open(parameter_file).expect("Error opening the file");
     let mut reader = BufReader::new(file);
     let mut buf = String::new();
     let _num_bytes = reader.read_line(&mut buf).unwrap();
@@ -135,7 +135,7 @@ pub fn set_default_waveform(waveform: u8) {
 }
 
 pub fn get_default_waveform() -> u8{
-   read_ebc_file("default_waveform").parse::<u8>().unwrap()
+    read_ebc_file("default_waveform").parse::<u8>().unwrap()
 }
 
 pub fn get_bw_mode() -> u8{


### PR DESCRIPTION
- Add signals
- Reorder methods (get, then set) and general consistency of method and variable names
- Deprecate `GetAutorefresh` in favour of more consistent `GetAutoRefresh`
- Add helper function to read to boolean values
- Add helpful debug messages
- Consistent indentation